### PR TITLE
rev update-notifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sw-precache",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Generates a service worker to cache your local App Shell resources.",
   "author": {
     "name": "Jeff Posnick",
@@ -50,7 +50,7 @@
     "mkdirp": "^0.5.1",
     "pretty-bytes": "^4.0.2",
     "sw-toolbox": "^3.4.0",
-    "update-notifier": "^1.0.3"
+    "update-notifier": "^2.3.0"
   },
   "repository": "googlechrome/sw-precache",
   "bugs": "https://github.com/googlechrome/sw-precache/issues",


### PR DESCRIPTION
Fixes #339

Revs a dependency that is a major version out of date, resulting in a downstream dependency on `got@5.7.1` which has an `engines` flag set to only allow installation in projects with a node.js version < 7.

```
sw-precache@5.2.0 
`-- update-notifier@1.0.3
  `-- latest-version@2.0.0
    `-- package-json@2.4.0
      `-- got@5.7.1
```
vs
```
sw-precache@5.2.1
└─┬ update-notifier@2.3.0
  └─┬ latest-version@3.1.0
    └─┬ package-json@4.0.1
      └── got@6.7.1 
```
Use case: If someone is using sw-precache@5.2.0, either directly or in their tree (say from create-react-app), and is specifying node 8 as their apps' minimum `engines` setting to enforce consistency, AND has the npm `engine-strict=true` flag set... `npm install` will fail.

```
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for got@5.7.1: wanted: {"node":">=0.10.0 <7"} (current: {"node":"8.9.4","npm":"5.6.0"})
npm ERR! notsup Not compatible with your version of node/npm: got@5.7.1
npm ERR! notsup Not compatible with your version of node/npm: got@5.7.1
npm ERR! notsup Required: {"node":">=0.10.0 <7"}
npm ERR! notsup Actual:   {"npm":"5.6.0","node":"8.9.4"}
```

Feel free to tell me if this is a stupid/too narrow a use-case reason for a PR, but I thought I would give it a shot =)